### PR TITLE
Check for expired and revoked keys

### DIFF
--- a/humans/forms.py
+++ b/humans/forms.py
@@ -1,7 +1,7 @@
 from django.forms import ModelForm
-from django.conf import settings
 from django import forms
 from .models import User
+from .utils import key_state
 import requests
 
 
@@ -12,25 +12,37 @@ class UpdateUserInfoForm(ModelForm):
             "first_name",
             "last_name",
             "organization",
+            "keyserver_url",
             "public_key",
             "fingerprint",
-            "keyserver_url",
             "timezone"
         ]
         widgets = {
             'keyserver_url': forms.TextInput(attrs={'placeholder': 'https://pgp.mit.edu/pks/lookup?op=get&search=0x0C3B29C1685EA5C4'})
         }
 
+    def __init__(self, *args, **kwargs):
+        self.pub_key = None
+        return super().__init__(*args, **kwargs)
+
     def clean_public_key(self):
         # Validate the public key
-        pub_key = self.cleaned_data.get("public_key", "")
+        if self.pub_key:
+            pub_key = self.pub_key
+        else:
+            pub_key = self.cleaned_data.get("public_key", "")
+
         if pub_key:
+            fingerprint, state = key_state(pub_key)
             # Check if has valid format
-            result = settings.GPG_OBJ.import_keys(pub_key)
-            if result.results[0]['fingerprint'] is None:
+            if state == "invalid":
                 self.add_error('public_key', "This key is not valid")
-            # Check if it is not expired TODO
-            # Check if is was not revoked TODO
+            # Check if it is not expired
+            elif state == "revoked":
+                self.add_error('public_key', "This key is revoked")
+            # Check if is was not revoked
+            elif state == "expired":
+                self.add_error('public_key', "This key is expired")
         return pub_key
 
     def clean_fingerprint(self):
@@ -39,14 +51,13 @@ class UpdateUserInfoForm(ModelForm):
         fingerprint = self.cleaned_data.get("fingerprint", "")
         fingerprint = fingerprint.replace(" ", "")
         if pub_key:
-            result = settings.GPG_OBJ.import_keys(pub_key).results[0]
-            if fingerprint != result["fingerprint"]:
+            key_fingerprint, state = key_state(pub_key)
+            if fingerprint != key_fingerprint:
                 self.add_error('fingerprint', "Fingerprint does not match")
         return fingerprint
 
-    def clean(self):
-        cleaned_data = super().clean()
-        url = cleaned_data.get("keyserver_url", "")
+    def clean_keyserver_url(self):
+        url = self.cleaned_data.get("keyserver_url", "")
         if url:
             try:
                 res = requests.get(url)
@@ -56,8 +67,8 @@ class UpdateUserInfoForm(ModelForm):
             begin = res.text.find("-----BEGIN PGP PUBLIC KEY BLOCK-----")
             end = res.text.find("-----END PGP PUBLIC KEY BLOCK-----")
             if 200 <= res.status_code < 300 and begin >= 0 and end > begin:
-                cleaned_data["public_key"] = res.text[begin:end + 34]
+                self.pub_key = res.text[begin:end + 34]
             else:
                 self.add_error("keyserver_url",
                                "This url does not have a pgp key")
-        return cleaned_data
+        return url

--- a/humans/tasks.py
+++ b/humans/tasks.py
@@ -1,0 +1,77 @@
+from celery.task.schedules import crontab
+from celery.decorators import periodic_task
+from celery.utils.log import get_task_logger
+from django.core.mail import EmailMultiAlternatives
+from django.conf import settings
+from django.db.models import Q
+from django.template.loader import render_to_string
+from .models import User
+from .utils import key_state
+import requests
+
+logger = get_task_logger(__name__)
+
+
+def fetch_key(url):
+    res = requests.get(url)
+    begin = res.text.find("-----BEGIN PGP PUBLIC KEY BLOCK-----")
+    end = res.text.find("-----END PGP PUBLIC KEY BLOCK-----")
+    if 200 <= res.status_code < 300 and begin >= 0 and end > begin:
+        return res.text[begin:end + 34]
+    else:
+        raise ValueError("The Url provided does not contain a public key")
+
+
+def send_email(user, subject, template):
+    content = render_to_string(template, context={"user": user})
+    email = EmailMultiAlternatives(subject, content,
+                                   settings.DEFAULT_FROM_EMAIL,
+                                   [user.email])
+    email.send()
+
+
+# Every day at 4 AM UTC
+@periodic_task(run_every=(crontab(minute=0, hour=4)), ignore_result=True)
+def update_public_keys():
+    users = User.objects.exclude(
+        Q(keyserver_url__isnull=True) | Q(keyserver_url__exact=''))
+    logger.info("Start updating user keys")
+    for user in users:
+        logger.info("Working on user: {}".format(user.email))
+        logger.info("URL: {}".format(user.keyserver_url))
+        try:
+            key = fetch_key(user.keyserver_url)
+        except:
+            logger.error("Unable to fetch new key")
+            continue
+
+        # Check key
+        fingerprint, state = key_state(key)
+
+        if state in ["expired", "revoked"]:
+            # Email user and disable/remove key
+            send_email(user, "Hawkpost: {} key".format(state),
+                       "humans/emails/key_{}.txt".format(state))
+            user.fingerprint = ""
+            user.public_key = ""
+            user.keyserver_url = ""
+            user.save()
+        elif state == "invalid":
+            # Alert the user and remove keyserver_url
+            send_email(user,
+                       "Hawkpost: Keyserver Url providing an invalid key",
+                       "humans/emails/key_invalid.txt")
+            user.keyserver_url = ""
+            user.save()
+        elif fingerprint != user.fingerprint:
+            # Email user and remove the keyserver url
+            send_email(user, "Hawkpost: Fingerprint mismatch",
+                       "humans/emails/fingerprint_changed.txt")
+            user.keyserver_url = ""
+            user.save()
+        elif state == "valid":
+            # Update the key store in the database
+            user.public_key = key
+            user.save()
+
+    logger.info("Finished Updating user keys")

--- a/humans/templates/humans/emails/fingerprint_changed.txt
+++ b/humans/templates/humans/emails/fingerprint_changed.txt
@@ -1,0 +1,10 @@
+Hello {% if user.first_name %} {{user.first_name}} {{user.last_name}} {% else %} {{user.username}} {% endif %},
+
+On the automatic key checks and updates using the keyserver url that you provided, the system spotted that the key present on that URL, no longer has the same fingerprint that the one you provided on your settings.
+
+To avoid using the wrong key, we removed the provided URL and will continue to use the key we have stored (all open boxes will remmain active).
+
+To enable the automatic verifications again, go to the settings and update your keyserver url.
+
+best regards,
+Hawkpost Team

--- a/humans/templates/humans/emails/key_expired.txt
+++ b/humans/templates/humans/emails/key_expired.txt
@@ -1,0 +1,8 @@
+Hello {% if user.first_name %} {{user.first_name}} {{user.last_name}} {% else %} {{user.username}} {% endif %},
+
+On the automatic key checks and updates using the keyserver url that you provided, the system spotted that your current key is already expired. To avoid any issues, the key was removed and all open boxes deactivated until a new one is added.
+
+To enable all functionality again, please go to the settings and add your new public key.
+
+best regards,
+Hawkpost Team

--- a/humans/templates/humans/emails/key_invalid.txt
+++ b/humans/templates/humans/emails/key_invalid.txt
@@ -1,0 +1,10 @@
+Hello {% if user.first_name %} {{user.first_name}} {{user.last_name}} {% else %} {{user.username}} {% endif %},
+
+On the automatic key checks and updates using the keyserver url that you provided, the system spotted that the key that is currently present on that URL is invalid (probably due a change in the document).
+
+To avoid using the wrong key, we removed the provided URL and will continue to use the key that we have stored (all open boxes will remmain active).
+
+To enable the automatic verifications again, go to the settings and update your keyserver url.
+
+best regards,
+Hawkpost Team

--- a/humans/templates/humans/emails/key_revoked.txt
+++ b/humans/templates/humans/emails/key_revoked.txt
@@ -1,0 +1,8 @@
+Hello {% if user.first_name %} {{user.first_name}} {{user.last_name}} {% else %} {{user.username}} {% endif %},
+
+On the automatic key checks and updates using the keyserver url that you provided, the system spotted that your current key was revoked. To avoid any issue or compromise, the key was removed and all open boxes deactivated until a new one is added.
+
+To enable all functionality again, please go to the settings and add your new public key.
+
+best regards,
+Hawkpost Team

--- a/humans/utils.py
+++ b/humans/utils.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from django.utils import timezone
+from datetime import datetime
+
+
+def key_state(key):
+    results = settings.GPG_OBJ.import_keys(key).results
+    keys = settings.GPG_OBJ.list_keys()
+    if not results or not results[0]["fingerprint"]:
+        return None, "invalid"
+    else:
+        state = "valid"
+        result = results[0]
+    for key in keys:
+        if key["fingerprint"] == result["fingerprint"]:
+            exp_timestamp = int(key["expires"]) if key["expires"] else ""
+            expires = datetime.fromtimestamp(exp_timestamp, timezone.utc)
+            if key["trust"] == "r":
+                state = "revoked"
+            elif exp_timestamp and expires < timezone.now():
+                state = "expired"
+            break
+    return result["fingerprint"], state


### PR DESCRIPTION
This PR handles the following issues:
- Fixes a bug that lets the users submit a key, without fingerprint check
- Add revoke and expiration checks to settings form
- Adds a daily task to update and check the users keys (Issue: https://github.com/whitesmith/hawkpost/issues/1)
