### PR TITLE
Fix 'float is required' when key has no exp date

### DIFF
--- a/humans/utils.py
+++ b/humans/utils.py
@@ -13,7 +13,7 @@ def key_state(key):
         result = results[0]
     for key in keys:
         if key["fingerprint"] == result["fingerprint"]:
-            exp_timestamp = int(key["expires"]) if key["expires"] else ""
+            exp_timestamp = int(key["expires"]) if key["expires"] else 0
             expires = datetime.fromtimestamp(exp_timestamp, timezone.utc)
             if key["trust"] == "r":
                 state = "revoked"


### PR DESCRIPTION
When the key has no expiration date it is defaulting to an empty string, which later throws an error when creating the expire date timestamp. Defaulting to 0 (which evaluates to false).
