### PR TITLE
Mark box that was just created

### DIFF
--- a/boxes/templates/boxes/box_list.html
+++ b/boxes/templates/boxes/box_list.html
@@ -17,7 +17,7 @@
     <div class="row">
         {% for box in object_list %}
             <div class="col-xxs-12 col-xs-6 col-sm-6 col-md-4">
-                <div class="box">
+                <div class="box {% if box.uuid|lower == new_box %}new-box{% endif %}">
                     <h3 class="box__title">{{box.name}}</h3>
                     <p class="box__desc">{{box.description}}</p>
 

--- a/boxes/views.py
+++ b/boxes/views.py
@@ -28,6 +28,7 @@ class BoxListView(LoginRequiredMixin, ListView):
         context["form"] = CreateBoxForm()
         context["domain"] = settings.SITE_DOMAIN
         context["display_status"] = self.request.GET.get("display", "Open")
+        context["new_box"] = self.request.GET.get("new_box", "")
         context["allow_actions"] = Box.OPEN
         return context
 
@@ -59,7 +60,8 @@ class BoxCreateView(LoginRequiredMixin, CreateView):
                                   user=self.request.user)
 
         messages.success(self.request, "Box created successfully")
-        return HttpResponseRedirect(self.get_success_url())
+        url = self.get_success_url() + "?new_box={}".format(self.object.uuid)
+        return HttpResponseRedirect(url)
 
 
 class BoxDeleteView(LoginRequiredMixin, DeleteView):


### PR DESCRIPTION
After the creation of a box, it should be highlighted to be easy to spot.

This is a small improvement related with issue #68 , that will be handled in the next milestone.
