### PR TITLE
Celery errors to Sentry

### DIFF
--- a/hawkpost/celery.py
+++ b/hawkpost/celery.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
-
-import os
 from dotenv import read_dotenv
-
-from celery import Celery
+from raven import Client
+from raven.contrib.celery import register_signal, register_logger_signal
+from celery import Celery as BaseCelery
+import os
 
 read_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env'))
 # set the default Django settings module for the 'celery' program.
@@ -13,8 +13,19 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE",
 
 from django.conf import settings  # noqa
 
-app = Celery('hawkpost')
 
+class Celery(BaseCelery):
+    def on_configure(self):
+        client = Client(settings.RAVEN_CONFIG["dsn"])
+        # register a custom filter to filter out duplicate logs
+        register_logger_signal(client)
+        # hook into the Celery error handler
+        register_signal(client)
+
+if environment == "development":
+    app = BaseCelery('hawkpost')
+else:
+    app = Celery('hawkpost')
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
 app.config_from_object('django.conf:settings')


### PR DESCRIPTION
On production only web app errors and exceptions are being sent to Sentry. 
This PR changes that, from now on any error that happens on the worker processes also show up on the specified sentry server. 
