### PR TITLE
Send encrypted message through a hidden field

### DIFF
--- a/boxes/static/javascripts/box_submit.js
+++ b/boxes/static/javascripts/box_submit.js
@@ -7,7 +7,7 @@ $(document).ready(function(){
     var contentType = serverSigned ? 'Content-Type: text/plain\n\n' : '';
 
     var options = {
-      data: contentType + $("#id_message").val(),
+      data: contentType + $("#id_plain").val(),
       // Works for one key, need to change when multiple recipients is available
       publicKeys: openpgp.key.readArmored($(".public-key-js").html()).keys
     };
@@ -45,6 +45,8 @@ $(document).ready(function(){
   */
   var createBox = function(){
     var $formDiv = $(".form-div-js");
+
+    /* Hidden form fields */
     var csrfToken = $formDiv.attr("data-csrf-token");
     var action = $formDiv.attr("data-action");
 
@@ -54,16 +56,21 @@ $(document).ready(function(){
 
     var $csrfTokenField = $("<input type='hidden' name='csrfmiddlewaretoken'></input>");
     $csrfTokenField.val(csrfToken);
+    $form.append($csrfTokenField);
 
-    var $label = $("<label for='id_message'></label>");
-    var $textArea = $("<textarea id='id_message' name='message' cols='40' rows='10'></textarea>");
+    var $encryptedMessage = $("<input id='id_message' name='message' type='hidden'></input>");
+    $form.append($encryptedMessage);
+
+    $formDiv.append($form);
+
+    /* Input fields */
+    var $label = $("<label for='id_plain'></label>");
+    var $textArea = $("<textarea id='id_plain' cols='40' rows='10'></textarea>");
     $textArea.attr("placeholder", "All the contents, inserted into this box, will be encrypted with " +
                                   "the recipient's public key before leaving this computer.")
 
-    $form.append($csrfTokenField);
-    $form.append($("<p class='no-margin-top'></p>").append($label).append($textArea));
-    $form.append($("<a id='encrypt-action-js' class='btn-blue smalltext u-blockify'>Encrypt and Send</a>"));
-    $formDiv.append($form);
+    $formDiv.append($("<p class='no-margin-top'></p>").append($label).append($textArea));
+    $formDiv.append($("<a id='encrypt-action-js' class='btn-blue smalltext u-blockify'>Encrypt and Send</a>"));
 
     $("#encrypt-action-js").on("click", encryptContent);
   }

--- a/boxes/static/javascripts/box_submit.js
+++ b/boxes/static/javascripts/box_submit.js
@@ -35,9 +35,11 @@ $(document).ready(function(){
     var message = $("#id_message").val();
     var lines = message.split("\n");
 
-    if (lines[0] === begin && lines[lines.length - 2] === end)
-      return true;
-    return false;
+    if (lines[0] !== begin || lines[lines.length - 2] !== end) {
+      return false;
+    }
+
+    return true;
   }
 
   /*

--- a/boxes/static/javascripts/box_submit.js
+++ b/boxes/static/javascripts/box_submit.js
@@ -17,6 +17,10 @@ $(document).ready(function () {
 
       $("#id_message").val(ciphertext.data);
 
+      /* Also update the input box's message as a visual cue
+       * that it has been sent after being encrypted. */
+      $("#id_plain").val(ciphertext.data);
+
       if (quickCheckFormContent()) {
         $box.submit();
       } else {

--- a/boxes/static/javascripts/box_submit.js
+++ b/boxes/static/javascripts/box_submit.js
@@ -1,34 +1,37 @@
-$(document).ready(function(){
+$(document).ready(function () {
   /*
-    Encrypt the current form content
-  */
-  var encryptContent = function(){
+   * Encrypt the current form content
+   */
+  function encryptContent() {
     var serverSigned = $('.server-signed-js').text() === 'True';
     var contentType = serverSigned ? 'Content-Type: text/plain\n\n' : '';
 
     var options = {
       data: contentType + $("#id_plain").val(),
-      // Works for one key, need to change when multiple recipients is available
+      /* Works for one key, need to change when multiple recipients is available */
       publicKeys: openpgp.key.readArmored($(".public-key-js").html()).keys
     };
 
-    openpgp.encrypt(options).then(function(ciphertext) {
+    openpgp.encrypt(options).then(function (ciphertext) {
       var $box = $("#box");
+
       $("#id_message").val(ciphertext.data);
-      if (quickCheckFormContent()){
+
+      if (quickCheckFormContent()) {
         $box.submit();
       } else {
         alert("Well, encryption doesn't seem to be as it should. Try again.");
       }
     });
+
     return false;
   }
 
   /*
-    Might be useless but
-    Check that the content is really encrypted before submitting
-  */
-  var quickCheckFormContent = function(){
+   * Might be useless but
+   * Check that the content is really encrypted before submitting
+   */
+  function quickCheckFormContent() {
     var begin = "-----BEGIN PGP MESSAGE-----";
     var end = "-----END PGP MESSAGE-----";
 
@@ -43,9 +46,9 @@ $(document).ready(function(){
   }
 
   /*
-    Only when javascript is enabled, the form is created.
-  */
-  var createBox = function(){
+   * Only when javascript is enabled, the form is created.
+   */
+  function createBox() {
     var $formDiv = $(".form-div-js");
 
     /* Hidden form fields */
@@ -83,9 +86,9 @@ $(document).ready(function(){
   }
 
   /*
-    Show introduction tooltip on click
-  */
-  $(".hawkpost__block").click(function(){
+   * Show introduction tooltip on click
+   */
+  $(".hawkpost__block").click(function () {
     $(this).toggleClass("open__hawkpost__text");
     $(".hawkpost__block").not(this).removeClass("open__hawkpost__text");
   });

--- a/boxes/static/javascripts/box_submit.js
+++ b/boxes/static/javascripts/box_submit.js
@@ -52,7 +52,7 @@ $(document).ready(function(){
 
     var $form = $("<form></form>");
     $form.attr('id', "box").attr("action", action)
-    $form.attr("method", "post").addClass("form__wrap_msg link-box__box");
+    $form.attr("method", "post");
 
     var $csrfTokenField = $("<input type='hidden' name='csrfmiddlewaretoken'></input>");
     $csrfTokenField.val(csrfToken);
@@ -64,13 +64,18 @@ $(document).ready(function(){
     $formDiv.append($form);
 
     /* Input fields */
+    var $inputDiv = $("<div></div>");
+    $inputDiv.addClass("form__wrap_msg link-box__box");
+
     var $label = $("<label for='id_plain'></label>");
     var $textArea = $("<textarea id='id_plain' cols='40' rows='10'></textarea>");
     $textArea.attr("placeholder", "All the contents, inserted into this box, will be encrypted with " +
                                   "the recipient's public key before leaving this computer.")
 
-    $formDiv.append($("<p class='no-margin-top'></p>").append($label).append($textArea));
-    $formDiv.append($("<a id='encrypt-action-js' class='btn-blue smalltext u-blockify'>Encrypt and Send</a>"));
+    $inputDiv.append($("<p class='no-margin-top'></p>").append($label).append($textArea));
+    $inputDiv.append($("<a id='encrypt-action-js' class='btn-blue smalltext u-blockify'>Encrypt and Send</a>"));
+
+    $formDiv.append($inputDiv);
 
     $("#encrypt-action-js").on("click", encryptContent);
   }

--- a/boxes/views.py
+++ b/boxes/views.py
@@ -161,10 +161,15 @@ class BoxSubmitView(UpdateView):
         form = self.get_form(data={"data": request.POST})
         if form.is_valid():
             message = self.object.messages.create()
+
+            # Mark box as done
             if self.object.messages.count() >= self.object.max_messages:
                 self.object.status = Box.DONE
                 self.object.save()
+
+            # Schedule e-mail
             process_email.delay(message.id, form.cleaned_data)
+
             return self.response_class(
                 request=self.request,
                 template="boxes/success.html",


### PR DESCRIPTION
This PR uses a hidden field in order to separate the input area from the submitted form; this way there's a guarantee the payload is always encrypted when sent (since the field will only be set in JavaScript-enabled browsers). This PR's original goal is to fix encrypted payload corruption issues caused by some browser extensions.

Some code re-styling and :lipstick: was also performed to improve readability and code analysis.

Please review this PR (I advise checking the last commit separately), manually test it and ping me before merging it, since this should be tested by the original reports of the issue, in order to make sure this is effectively a fix.
