### PR TITLE
Removed wrong contact address

### DIFF
--- a/hawkpost/templates/account/email/email_confirmation_message.txt
+++ b/hawkpost/templates/account/email/email_confirmation_message.txt
@@ -10,7 +10,7 @@ You're receiving it, because you (or someone else) provided it during registrati
 
 To confirm this is correct, please visit the following address: {{ activate_url }}
 
-Otherwise you can either ignore this message or contact us through the support channels ( at {{ site_domain }}{% endblocktrans %}{% url 'pages_help' %} ){% blocktrans%}, so this account can be removed.
+Otherwise you can either ignore this message or contact us through the support channels (at {{ site_domain }}{% endblocktrans %}{% url 'pages_help' %}){% blocktrans %}, so this account can be removed.
 {% endblocktrans %}
 {% endautoescape %}
 

--- a/hawkpost/templates/account/email/email_confirmation_message.txt
+++ b/hawkpost/templates/account/email/email_confirmation_message.txt
@@ -10,7 +10,7 @@ You're receiving it, because you (or someone else) provided it during registrati
 
 To confirm this is correct, please visit the following address: {{ activate_url }}
 
-Otherwise you can either ignore this message or send us an email to "support@hawkpost.co" so this account can be removed.
+Otherwise you can either ignore this message or contact us through the support channels ( at {{ site_domain }}{% endblocktrans %}{% url 'pages_help' %} ){% blocktrans%}, so this account can be removed.
 {% endblocktrans %}
 {% endautoescape %}
 


### PR DESCRIPTION
The confirmation email contained a wrong email address.
This pull request, removed the static address and added a link to were people can get support information.