### PR TITLE
Fix clean keyserver_url

### DIFF
--- a/humans/forms.py
+++ b/humans/forms.py
@@ -68,6 +68,7 @@ class UpdateUserInfoForm(ModelForm):
             except:
                 self.add_error("keyserver_url",
                                "Could not access the specified url")
+                return url
             begin = res.text.find("-----BEGIN PGP PUBLIC KEY BLOCK-----")
             end = res.text.find("-----END PGP PUBLIC KEY BLOCK-----")
             if 200 <= res.status_code < 300 and begin >= 0 and end > begin:


### PR DESCRIPTION
This pull request fixes an issue with on the process of fetching the key from a keyserver url. This error was that the function was not returning when no contents were available, leading to a:

> UnboundLocalError: local variable 'res' referenced before assignment