### PR TITLE
ALLOWED_HOSTS overridable by env on development

### DIFF
--- a/hawkpost/settings/development.py
+++ b/hawkpost/settings/development.py
@@ -3,6 +3,9 @@ from .common import *
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
+if 'ALLOWED_HOSTS' in os.environ:
+    ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS").split(',')
+
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases
 


### PR DESCRIPTION
Allow `ALLOWED_HOSTS` to be overridden by environment variables; currently the Docker environment presents some issues when accessing the application through a different host (I personally use `hawkpost.dev` to point to the container's IP). This is a change that makes it _optionally overridden_, which means omitting the variable preserves the current behaviour.