### PR TITLE
[fix] Update user form: overlapping button

### DIFF
--- a/humans/templates/humans/update_user_form.html
+++ b/humans/templates/humans/update_user_form.html
@@ -85,15 +85,15 @@
                     </li>
                   </ul>
                 </div>
-                <div class="col-xs-12">
-                  <input type="submit" class="btn-blue set smalltext" value="{% trans "Save" %}" />
+                <div class="col-xs-12 form__block">
+                  <input type="submit" class="btn-blue smalltext" value="{% trans "Save" %}" />
                 </div>
               </div>
             </div>
           </form>
           <div class="text-center">
             <small class="check smalltext text-darkest">
-              {% trans "Do you wish to delete your account? if yes, just click" %}<a class="text-blue"href="{% url "humans_delete" %}">{% trans "here" %}</a>
+              {% trans "Do you wish to delete your account? if yes, just click" %} <a class="text-blue"href="{% url "humans_delete" %}">{% trans "here" %}</a>
             </small>
           </div>
         </div>

--- a/stylesheets/_forms.scss
+++ b/stylesheets/_forms.scss
@@ -284,10 +284,6 @@ form {
 
 #accordion {
     width: 100%;
-    height: 330px;
-    @include breakpoint ($min:xl) {
-        height: 450px;
-    }
     .section {
         display: none;
         &.active {


### PR DESCRIPTION
Fixes #245 

Changed the accordion form css so it won't use a fixed height anymore, avoiding the overlapping problem.

This introduces a different behavior for the "save" button: it isn't at the same position for the three tabs anymore, as now it varies with the height. From a UX point of view this feels more natural, specially on mobile.

Also added space between "clickhere".