### PR TITLE
Update project to the latest version of django

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,4 @@
-django==1.11.6
+django==1.11.7
 django-dotenv==1.4.1
 psycopg2==2.7.1
 django-allauth==0.32.0

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,7 @@
 django==1.11.7
 django-dotenv==1.4.1
 psycopg2==2.7.1
-django-allauth==0.32.0
+django-allauth==0.34.0
 gnupg==2.3.0
 whitenoise==3.3.0
 celery==4.0.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,7 +9,7 @@ billiard==3.5.0.2         # via celery
 celery==4.0.2
 contextlib2==0.5.1        # via raven
 defusedxml==0.4.1         # via python3-openid
-django-allauth==0.32.0
+django-allauth==0.34.0
 django-axes==2.3.3
 django-braces==1.11.0
 django-dotenv==1.4.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,7 +14,7 @@ django-axes==2.3.3
 django-braces==1.11.0
 django-dotenv==1.4.1
 django-timezone-field==2.0
-django==1.11.6
+django==1.11.7
 gnupg==2.3.0
 gunicorn==19.7.1
 kombu==4.0.2              # via celery

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -10,7 +10,7 @@ celery==4.0.2
 contextlib2==0.5.1        # via raven
 coverage==4.2
 defusedxml==0.4.1         # via python3-openid
-django-allauth==0.32.0
+django-allauth==0.34.0
 django-axes==2.3.3
 django-braces==1.11.0
 django-debug-toolbar==1.5

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -17,7 +17,7 @@ django-debug-toolbar==1.5
 django-dotenv==1.4.1
 django-extensions==1.7.2
 django-timezone-field==2.0
-django==1.11.6
+django==1.11.7
 fake-factory==0.5.3       # via hypothesis
 gnupg==2.3.0
 gunicorn==19.7.1


### PR DESCRIPTION
The version was updated to version 1.11.7. You can find the release notes [here](https://docs.djangoproject.com/en/1.11/releases/1.11.7/).

Also updated `django-allauth` package, since the earlier version had security issues ([check here](https://pyup.io/repos/github/whitesmith/hawkpost/commits/?page=1#b057bb3d384f43086ab819073ef37ff534885c32)).