### PR TITLE
Description should respect line breaks

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -59,7 +59,7 @@ var tasks = {};
 tasks.browser_sync = function () {
   var config = {
       proxy: {
-          target: "http://0.0.0.0:8000",
+          target: "http://localhost:8000",
           ws: true
       },
       ghostMode: {

--- a/boxes/templates/boxes/box_list.html
+++ b/boxes/templates/boxes/box_list.html
@@ -136,7 +136,7 @@
             </p>
             <div class="row middle-xs">
               <div class="col-xs-9 col-xxs-12 col-sm-8">
-                <p>
+                <p class="multiline-input">
                   <span id="description-errors-js">{{ form.description.errors }}</span>
                   {{ form.description.label_tag }}
                   {{ form.description }}

--- a/boxes/templates/boxes/box_list.html
+++ b/boxes/templates/boxes/box_list.html
@@ -36,7 +36,7 @@
               <div class="basic-info">
                 <div class="box-title-desc">
                   <p class="xmb-small textbold text-darkest">{{box.name}}</p>
-                  <p class="xmb-small smalltext text-darkest">{{box.description}}</p>
+                  <p class="xmb-small smalltext text-darkest">{{box.description|linebreaks}}</p>
                 </div>
               </div>
             </div>

--- a/boxes/templates/boxes/box_submit.html
+++ b/boxes/templates/boxes/box_submit.html
@@ -52,7 +52,7 @@
           <div class="row">
             <div class="text-left  col-xs-8 col-sm-11 col-md-11  col-lg-7">
               <p class="textbold text-darkest no-margin">{{object.name}}</p>
-              <p class="xmt-small smalltext no-margin-bottom">{{object.description}}</p>
+              <p class="xmt-small smalltext no-margin-bottom">{{object.description|linebreaks}}</p>
             </div>
           </div>
         </div>

--- a/stylesheets/_newbox.scss
+++ b/stylesheets/_newbox.scss
@@ -22,7 +22,7 @@
 
 textarea {
     width: 100%;
-    height: 5vh;
+    height: 8vh !important;
     border-color: $light;
     resize: none;
     &:focus {

--- a/stylesheets/_newbox.scss
+++ b/stylesheets/_newbox.scss
@@ -22,7 +22,7 @@
 
 textarea {
     width: 100%;
-    height: 8vh !important;
+    height: 5vh;
     border-color: $light;
     resize: none;
     &:focus {
@@ -30,6 +30,10 @@ textarea {
         border: 1px solid rgba($main-color-dark, 0.5);
         box-shadow: inset 0 1px 1px rgba($main-color-dark, 0.3);
     }
+}
+
+.multiline-input textarea {
+    height: 8vh;
 }
 
 input {


### PR DESCRIPTION
Box description should be a multi-line input, where users can add instructions and other information about how/what to submit the box contents or the purpose of the box. 

At the moment those lines breaks are not respected and the input looks line it only supports one line. This pull request changes that.