### PR TITLE
reply_to is filled if the user is authenticated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ Session.vim
 
 # MacOS Stuff
 .DS_Store
+
+# Editor Stuff
+.vscode

--- a/boxes/forms.py
+++ b/boxes/forms.py
@@ -53,6 +53,7 @@ class CreateBoxForm(ModelForm):
 class SubmitBoxForm(Form):
     message = CharField(widget=Textarea, required=True)
     file_name = CharField(required=False)
+    add_reply_to = BooleanField(required=False)
 
     def clean_message(self):
         # Quick check if the message really came encrypted

--- a/boxes/static/javascripts/box_submit.js
+++ b/boxes/static/javascripts/box_submit.js
@@ -126,6 +126,7 @@ $(document).ready(function () {
    * Only when javascript is enabled, the form is created.
    */
   function createBox() {
+    var authenticated_user = $("#authenticated_user").length
     var $formDiv = $(".form-div-js");
 
     /* Hidden form fields */
@@ -145,6 +146,13 @@ $(document).ready(function () {
 
     var $encryptedMessage = $("<input id='id_message' name='message' type='hidden'></input>");
     $form.append($encryptedMessage);
+
+    if (authenticated_user) {
+      var $replyLabel = $("<label id='id_reply_label' for='id_add_reply_to'>Add own email to ReplyTo</label>");
+      var $replyInput = $("<input class='box_submit_input' id='id_add_reply_to' name='add_reply_to' type='checkbox'></input>");
+      var $replyGroup = $("<div class='box_submit_checkbox'></div>").append($replyLabel).append($replyInput);
+      $form.append($replyGroup);
+    }
 
     $formDiv.append($form);
 

--- a/boxes/tasks.py
+++ b/boxes/tasks.py
@@ -10,22 +10,30 @@ from celery import shared_task
 
 
 @shared_task
-def process_email(message_id, form_data):
+def process_email(message_id, form_data, sent_by=None):
     message = Message.objects.get(id=message_id)
     box = message.box
     msg = form_data["message"]
     file_name = form_data.get("file_name", "")
     subject = _('New submission to your box: {}').format(box)
+    reply_to = [sent_by] if sent_by else []
 
     if file_name:
         body = _("The submitted file can be found in the attachments.")
         email = EmailMultiAlternatives(
-            subject, body, settings.DEFAULT_FROM_EMAIL, [box.owner.email],
-            attachments=[(file_name, msg, "application/octet-stream")])
+            subject,
+            body,
+            settings.DEFAULT_FROM_EMAIL,
+            [box.owner.email],
+            reply_to=reply_to,
+            attachments=[(file_name, msg, "application/octet-stream")]
+        )
     else:
-        email = EmailMultiAlternatives(subject, msg,
+        email = EmailMultiAlternatives(subject,
+                                       msg,
                                        settings.DEFAULT_FROM_EMAIL,
-                                       [box.owner.email])
+                                       [box.owner.email],
+                                       reply_to=reply_to)
 
     # Output e-mail message for debug purposes
     # with open('email.mbox', 'w') as f:

--- a/boxes/templates/boxes/box_submit.html
+++ b/boxes/templates/boxes/box_submit.html
@@ -54,6 +54,9 @@
               <p class="xmt-small smalltext no-margin-bottom">{{object.description|linebreaks}}</p>
             </div>
           </div>
+          {% if request.user.is_authenticated %}
+          <input type="hidden" id="authenticated_user">
+          {% endif %}
         </div>
       </div>
     </div>

--- a/boxes/tests.py
+++ b/boxes/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.utils import timezone
 from django.core.urlresolvers import reverse
+from django.core import mail
 from humans.models import User
 from datetime import timedelta
 from .models import Box, Message
@@ -247,8 +248,8 @@ class MailTaskTests(TestCase):
 
     def test_email_sending(self):
         """
-            With a valid box_id an email is sent and the box status is changed
-            to sent
+            With a valid message_id an email is sent and the Message status
+            is changed to sent
         """
         user = create_and_login_user(self.client)
         create_boxes(user)
@@ -257,5 +258,21 @@ class MailTaskTests(TestCase):
         process_email(message.id, {"message": ENCRYPTED_MESSAGE})
         after_box = user.own_boxes.get(id=initial_box.id)
         after_msg = after_box.messages.get(id=message.id)
-        #self.assertEqual(message.status, Message.SENT)
+        message.refresh_from_db()
+        self.assertEqual(message.status, Message.SENT)
         self.assertEqual(after_msg.sent_at, after_box.last_sent_at)
+        self.assertEqual(len(mail.outbox[0].reply_to), 0)
+
+    def test_email_sending_with_reply_to(self):
+        mail.outbox = []
+        user = create_and_login_user(self.client)
+        create_boxes(user)
+        initial_box = user.own_boxes.all()[0]
+        message = initial_box.messages.create()
+        process_email(
+            message.id, {"message": ENCRYPTED_MESSAGE}, sent_by=user.email
+        )
+        message.refresh_from_db()
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn(user.email, mail.outbox[0].reply_to)
+        self.assertEqual(message.status, Message.SENT)

--- a/boxes/tests.py
+++ b/boxes/tests.py
@@ -160,6 +160,17 @@ class SubmitBoxFormTests(TestCase):
                               "file_name": "test"})
         self.assertEqual(form.is_valid(), True)
 
+    def test_add_reply_to_is_present(self):
+        form = SubmitBoxForm({"message": ENCRYPTED_MESSAGE,
+                              "add_reply_to": "on"})
+        self.assertEqual(form.is_valid(), True)
+        self.assertTrue(form.cleaned_data.get("add_reply_to"))
+
+    def test_add_reply_to_is_not_present(self):
+        form = SubmitBoxForm({"message": ENCRYPTED_MESSAGE})
+        self.assertEqual(form.is_valid(), True)
+        self.assertFalse(form.cleaned_data.get("add_reply_to"))
+
 
 class BoxListViewTests(TestCase):
 

--- a/boxes/views.py
+++ b/boxes/views.py
@@ -173,8 +173,15 @@ class BoxSubmitView(UpdateView):
                 self.object.status = Box.DONE
                 self.object.save()
 
+            if request.user.is_authenticated():
+                user_email = request.user.email
+            else:
+                user_email = None
+
             # Schedule e-mail
-            process_email.delay(message.id, form.cleaned_data)
+            process_email.delay(
+                message.id, form.cleaned_data, sent_by=user_email
+            )
 
             return self.response_class(
                 request=self.request,

--- a/boxes/views.py
+++ b/boxes/views.py
@@ -166,6 +166,7 @@ class BoxSubmitView(UpdateView):
     def post(self, request, *args, **kwargs):
         form = self.get_form(data={"data": request.POST})
         if form.is_valid():
+            cleaned_data = form.cleaned_data
             message = self.object.messages.create()
 
             # Mark box as done
@@ -173,7 +174,8 @@ class BoxSubmitView(UpdateView):
                 self.object.status = Box.DONE
                 self.object.save()
 
-            if request.user.is_authenticated():
+            add_user_email = cleaned_data.get("add_reply_to", False)
+            if request.user.is_authenticated() and add_user_email:
                 user_email = request.user.email
             else:
                 user_email = None


### PR DESCRIPTION
Addresses #218 

This is a simple implementation of a requested feature. If a user is logged in when submitting a box, the `reply_to` field will be filled with his email address. 

We could added a field for users not logged in, however we would have to validate the users is not trying to impersonate (not providing is own email address). 

A possible improvement for this PR, would be to allow the logged in user to opt out of this feature.
Would that be preferable?