### PR TITLE
Update older dependencies and remove "mail_debug"

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,23 +6,21 @@ name = "pypi"
 [dev-packages]
 django-debug-toolbar = "==1.9.1"
 django-extensions = "*"
-hypothesis = {extras = ["django"]}
-coverage = "*"
 
 [packages]
 django-dotenv = "==1.4.1"
 "psycopg2" = "==2.7.3.2"
-django-allauth = "==0.34.0"
+django-allauth = "==0.42.0"
 gnupg = "==2.3.1"
 whitenoise = "==4.1.4"
 celery = "==4.1.1"
-redis = "==2.10.5"
+redis = "==3.2.0"
 gunicorn = "==19.7.1"
 raven = "==6.1.0"
 django-timezone-field = "==2.0"
 django-braces = "==1.11.0"
-django-axes = "==2.3.3"
-Django = "==1.11.29"
+django-axes = "==5.3.3"
+Django = "==2.2.13"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b1ef190d8ea2a5bf000db28762a56fa862debe0ad39e2059d442bcb50614beb8"
+            "sha256": "27a80150f8689f345df8420b1203723e20f436e977c2b4032aaccb3a1d4f0d64"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -21,6 +21,7 @@
                 "sha256:24dbaff8ce4f30566bb88976b398e8c4e77637171af3af6f1b9650f48890e60b",
                 "sha256:bb68f8d2bced8f93ccfd07d96c689b716b3227720add971be980accfc2952139"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.6.0"
         },
         "billiard": {
@@ -39,10 +40,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
-                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
+                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
             ],
-            "version": "==2020.4.5.1"
+            "version": "==2020.6.20"
         },
         "chardet": {
             "hashes": [
@@ -56,6 +57,7 @@
                 "sha256:01f490098c18b19d2bd5bb5dc445b2054d2fa97f09a4280ba2c5f3c394c8162e",
                 "sha256:3355078a159fbb44ee60ea80abd0d87b80b78c248643b49aa6d94673b413609b"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.6.0.post1"
         },
         "defusedxml": {
@@ -63,29 +65,38 @@
                 "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
                 "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.6.0"
         },
         "django": {
             "hashes": [
-                "sha256:014e3392058d94f40569206a24523ce254d55ad2f9f46c6550b0fe2e4f94cf3f",
-                "sha256:4200aefb6678019a0acf0005cd14cfce3a5e6b9b90d06145fcdd2e474ad4329c"
+                "sha256:84f370f6acedbe1f3c41e1a02de44ac206efda3355e427139ecb785b5f596d80",
+                "sha256:e8fe3c2b2212dce6126becab7a693157f1a441a07b62ec994c046c76af5bb66d"
             ],
             "index": "pypi",
-            "version": "==1.11.29"
+            "version": "==2.2.13"
         },
         "django-allauth": {
             "hashes": [
-                "sha256:95a9f7fbebe3e97ce3a541d213fc52492b50dac92f0f91483f58949189e5aa4f"
+                "sha256:f17209410b7f87da0a84639fd79d3771b596a6d3fc1a8e48ce50dabc7f441d30"
             ],
             "index": "pypi",
-            "version": "==0.34.0"
+            "version": "==0.42.0"
+        },
+        "django-appconf": {
+            "hashes": [
+                "sha256:1b1d0e1069c843ebe8ae5aa48ec52403b1440402b320c3e3a206a0907e97bb06",
+                "sha256:be58deb54a43d77d2e1621fe59f787681376d3cd0b8bd8e4758ef6c3a6453380"
+            ],
+            "version": "==1.0.4"
         },
         "django-axes": {
             "hashes": [
-                "sha256:408344fe851d468df617d28809cf8c4196e33138744b5b9af5f8b13d0a74aca5"
+                "sha256:05eb551754da8dbf59c89cdfbe992679c2a586b8c22ed8a2442c7626ce3d9837",
+                "sha256:fe1ca82d8c2880439ee5ce9f7f8f15dd543529364161dffe1677b39fa2ac1f13"
             ],
             "index": "pypi",
-            "version": "==2.3.3"
+            "version": "==5.3.3"
         },
         "django-braces": {
             "hashes": [
@@ -103,6 +114,12 @@
             "index": "pypi",
             "version": "==1.4.1"
         },
+        "django-ipware": {
+            "hashes": [
+                "sha256:a7c7a8fd019dbdc9c357e6e582f65034e897572fc79a7e467674efa8aef9d00b"
+            ],
+            "version": "==2.1.0"
+        },
         "django-timezone-field": {
             "hashes": [
                 "sha256:8d368d15f19d39c887cb59606a4e5897b7366c7552cae3b1da421bc939696968"
@@ -112,7 +129,9 @@
         },
         "gnupg": {
             "hashes": [
-                "sha256:8db5a05c369dbc231dab4c98515ce828f2dffdc14f1534441a6c59b71c6d2031"
+                "sha256:8db5a05c369dbc231dab4c98515ce828f2dffdc14f1534441a6c59b71c6d2031",
+                "sha256:be656a2f693dbac4362537c1b6cfd03131ac5ce7a4b2bb21bff7e3145f94f7ea",
+                "sha256:d2e16c486aaeecbb65633f8493ccab025e2487c0e1dc59a83c520b6f81dff9b8"
             ],
             "index": "pypi",
             "version": "==2.3.1"
@@ -130,28 +149,31 @@
                 "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
                 "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
+                "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83",
+                "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
+            "version": "==1.7.0"
         },
         "kombu": {
             "hashes": [
-                "sha256:437b9cdea193cc2ed0b8044c85fd0f126bb3615ca2f4d4a35b39de7cacfa3c1a",
-                "sha256:dc282bb277197d723bccda1a9ba30a27a28c9672d0ab93e9e51bb05a37bd29c3"
+                "sha256:be48cdffb54a2194d93ad6533d73f69408486483d189fe9f5990ee24255b0e0a",
+                "sha256:ca1b45faac8c0b18493d02a8571792f3c40291cf2bcf1f55afed3d8f3aa7ba74"
             ],
-            "version": "==4.6.10"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.6.11"
         },
         "oauthlib": {
             "hashes": [
                 "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889",
                 "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.1.0"
         },
         "psutil": {
@@ -168,6 +190,7 @@
                 "sha256:e2d0c5b07c6fe5a87fa27b7855017edb0d52ee73b71e6ee368fae268605cc3f5",
                 "sha256:f344ca230dd8e8d5eee16827596f1c22ec0876127c28e800d7ae20ed44c4b310"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==5.7.0"
         },
         "psycopg2": {
@@ -231,31 +254,42 @@
         },
         "redis": {
             "hashes": [
-                "sha256:5dfbae6acfc54edf0a7a415b99e0b21c0a3c27a7f787b292eea727b1facc5533",
-                "sha256:97156b37d7cda4e7d8658be1148c983984e1a975090ba458cc7e244025191dbd"
+                "sha256:724932360d48e5407e8f82e405ab3650a36ed02c7e460d1e6fddf0f038422b54",
+                "sha256:9b19425a38fd074eb5795ff2b0d9a55b46a44f91f5347995f27e3ad257a7d775"
             ],
             "index": "pypi",
-            "version": "==2.10.5"
+            "version": "==3.2.0"
         },
         "requests": {
             "hashes": [
-                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
-                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+                "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
+                "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
             ],
-            "version": "==2.23.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.24.0"
         },
         "requests-oauthlib": {
             "hashes": [
                 "sha256:7f71572defaecd16372f9006f33c2ec8c077c3cfa6f5911a9a90202beb513f3d",
-                "sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a"
+                "sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a",
+                "sha256:fa6c47b933f01060936d87ae9327fead68768b69c6c9ea2109c48be30f2d4dbc"
             ],
             "version": "==1.3.0"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:022fb9c87b524d1f7862b3037e541f68597a730a8843245c349fc93e1643dc4e",
+                "sha256:e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.3.1"
         },
         "urllib3": {
             "hashes": [
                 "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
                 "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.9"
         },
         "vine": {
@@ -263,6 +297,7 @@
                 "sha256:133ee6d7a9016f177ddeaf191c1f58421a1dcc6ee9a42c58b34bed40e1d2cd87",
                 "sha256:ea4947cc56d1fd6f2095c8d543ee25dad966f78692528e68b4fada11ba3f98af"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.3.0"
         },
         "whitenoise": {
@@ -278,69 +313,26 @@
                 "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
                 "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==3.1.0"
         }
     },
     "develop": {
         "asgiref": {
             "hashes": [
-                "sha256:8036f90603c54e93521e5777b2b9a39ba1bad05773fcf2d208f0299d1df58ce5",
-                "sha256:9ca8b952a0a9afa61d30aa6d3d9b570bb3fd6bafcf7ec9e6bed43b936133db1c"
+                "sha256:7e51911ee147dd685c3c8b805c0ad0cb58d360987b56953878f8c06d2d1c6f1a",
+                "sha256:9fc6fb5d39b8af147ba40765234fa822b39818b12cc80b35ad9b0cef3a476aed"
             ],
-            "version": "==3.2.7"
-        },
-        "attrs": {
-            "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
-            ],
-            "version": "==19.3.0"
-        },
-        "coverage": {
-            "hashes": [
-                "sha256:08907593569fe59baca0bf152c43f3863201efb6113ecb38ce7e97ce339805a6",
-                "sha256:0be0f1ed45fc0c185cfd4ecc19a1d6532d72f86a2bac9de7e24541febad72650",
-                "sha256:141f08ed3c4b1847015e2cd62ec06d35e67a3ac185c26f7635f4406b90afa9c5",
-                "sha256:19e4df788a0581238e9390c85a7a09af39c7b539b29f25c89209e6c3e371270d",
-                "sha256:23cc09ed395b03424d1ae30dcc292615c1372bfba7141eb85e11e50efaa6b351",
-                "sha256:245388cda02af78276b479f299bbf3783ef0a6a6273037d7c60dc73b8d8d7755",
-                "sha256:331cb5115673a20fb131dadd22f5bcaf7677ef758741312bee4937d71a14b2ef",
-                "sha256:386e2e4090f0bc5df274e720105c342263423e77ee8826002dcffe0c9533dbca",
-                "sha256:3a794ce50daee01c74a494919d5ebdc23d58873747fa0e288318728533a3e1ca",
-                "sha256:60851187677b24c6085248f0a0b9b98d49cba7ecc7ec60ba6b9d2e5574ac1ee9",
-                "sha256:63a9a5fc43b58735f65ed63d2cf43508f462dc49857da70b8980ad78d41d52fc",
-                "sha256:6b62544bb68106e3f00b21c8930e83e584fdca005d4fffd29bb39fb3ffa03cb5",
-                "sha256:6ba744056423ef8d450cf627289166da65903885272055fb4b5e113137cfa14f",
-                "sha256:7494b0b0274c5072bddbfd5b4a6c6f18fbbe1ab1d22a41e99cd2d00c8f96ecfe",
-                "sha256:826f32b9547c8091679ff292a82aca9c7b9650f9fda3e2ca6bf2ac905b7ce888",
-                "sha256:93715dffbcd0678057f947f496484e906bf9509f5c1c38fc9ba3922893cda5f5",
-                "sha256:9a334d6c83dfeadae576b4d633a71620d40d1c379129d587faa42ee3e2a85cce",
-                "sha256:af7ed8a8aa6957aac47b4268631fa1df984643f07ef00acd374e456364b373f5",
-                "sha256:bf0a7aed7f5521c7ca67febd57db473af4762b9622254291fbcbb8cd0ba5e33e",
-                "sha256:bf1ef9eb901113a9805287e090452c05547578eaab1b62e4ad456fcc049a9b7e",
-                "sha256:c0afd27bc0e307a1ffc04ca5ec010a290e49e3afbe841c5cafc5c5a80ecd81c9",
-                "sha256:dd579709a87092c6dbee09d1b7cfa81831040705ffa12a1b248935274aee0437",
-                "sha256:df6712284b2e44a065097846488f66840445eb987eb81b3cc6e4149e7b6982e1",
-                "sha256:e07d9f1a23e9e93ab5c62902833bf3e4b1f65502927379148b6622686223125c",
-                "sha256:e2ede7c1d45e65e209d6093b762e98e8318ddeff95317d07a27a2140b80cfd24",
-                "sha256:e4ef9c164eb55123c62411f5936b5c2e521b12356037b6e1c2617cef45523d47",
-                "sha256:eca2b7343524e7ba246cab8ff00cab47a2d6d54ada3b02772e908a45675722e2",
-                "sha256:eee64c616adeff7db37cc37da4180a3a5b6177f5c46b187894e633f088fb5b28",
-                "sha256:ef824cad1f980d27f26166f86856efe11eff9912c4fed97d3804820d43fa550c",
-                "sha256:efc89291bd5a08855829a3c522df16d856455297cf35ae827a37edac45f466a7",
-                "sha256:fa964bae817babece5aa2e8c1af841bebb6d0b9add8e637548809d040443fee0",
-                "sha256:ff37757e068ae606659c28c3bd0d923f9d29a85de79bf25b2b34b148473b5025"
-            ],
-            "index": "pypi",
-            "version": "==4.5.4"
+            "markers": "python_version >= '3.5'",
+            "version": "==3.2.10"
         },
         "django": {
             "hashes": [
-                "sha256:014e3392058d94f40569206a24523ce254d55ad2f9f46c6550b0fe2e4f94cf3f",
-                "sha256:4200aefb6678019a0acf0005cd14cfce3a5e6b9b90d06145fcdd2e474ad4329c"
+                "sha256:84f370f6acedbe1f3c41e1a02de44ac206efda3355e427139ecb785b5f596d80",
+                "sha256:e8fe3c2b2212dce6126becab7a693157f1a441a07b62ec994c046c76af5bb66d"
             ],
             "index": "pypi",
-            "version": "==1.11.29"
+            "version": "==2.2.13"
         },
         "django-debug-toolbar": {
             "hashes": [
@@ -352,22 +344,11 @@
         },
         "django-extensions": {
             "hashes": [
-                "sha256:526d84b16ee180e45e2305f19d3e01ff3f9f513133839c0b4478b97310ade82a",
-                "sha256:a78105d5a5e1c3ef44fbe41bc5a19102bda64dbad05515bf791ac6d5d2499ebf"
+                "sha256:2f81b618ba4d1b0e58603e25012e5c74f88a4b706e0022a3b21f24f0322a6ce6",
+                "sha256:b19182d101a441fe001c5753553a901e2ef3ff60e8fbbe38881eb4a61fdd17c4"
             ],
             "index": "pypi",
-            "version": "==2.2.3"
-        },
-        "hypothesis": {
-            "extras": [
-                "django"
-            ],
-            "hashes": [
-                "sha256:54125db871db68cc4002b0d63645143e96ca27c13a4bccecc562f91e31af2418",
-                "sha256:9c1a37de7c74e3e04c4676bc9395e100905f4c3b1ed012238db4bb4f60a03207"
-            ],
-            "index": "pypi",
-            "version": "==4.40.0"
+            "version": "==2.2.9"
         },
         "pytz": {
             "hashes": [
@@ -381,6 +362,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "sqlparse": {
@@ -388,6 +370,7 @@
                 "sha256:022fb9c87b524d1f7862b3037e541f68597a730a8843245c349fc93e1643dc4e",
                 "sha256:e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.3.1"
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-Hawkpost
-========
+# Hawkpost
 
 Hawkpost lets you create unique links that you can share with the person that desires to send you important information but doesn't know how to deal with PGP.
 
 You can deploy your own server using the code from this repository or use the official server (that is running an exact copy of this repo) at [https://hawkpost.co](https://hawkpost.co).
-
 
 ## Rationale
 
@@ -17,44 +15,43 @@ The way it works is like this:
 1. The server then signs (**experimental**) the encrypted content.
 1. Finally the server forwards it to your e-mail address.
 
-
 # Setting up a development environment
 
 In this section you can find the steps to setup a minimal development environment on your machine.
 
 Base requirements:
 
-* Python 3
-* Redis
-* PostgreSQL
+- Python 3
+- Redis
+- PostgreSQL
 
 ## On Linux
 
 On a **Debian** based operating system execute the following steps, after cloning the repository:
 
-* Make sure you have `pipenv` installed. You can check [this page for more information](https://docs.pipenv.org/install/#installing-pipenv)
+- Make sure you have `pipenv` installed. You can check [this page for more information](https://docs.pipenv.org/install/#installing-pipenv)
 
-* Install the dependencies
+- Install the dependencies
 
 ```
 $ pipenv install
 ```
 
-* Create the local postgreSQL database with your user and no password
+- Create the local postgreSQL database with your user and no password
 
-* Migrate the database
+- Migrate the database
 
 ```
 $ pipenv run python manage.py migrate
 ```
 
-* Generate stylesheet with gulp (installation instructions for gulp can be found [here](https://gulpjs.com/))
+- Generate stylesheet with gulp (installation instructions for gulp can be found [here](https://gulpjs.com/))
 
 ```
 $ gulp build
 ```
 
-* Now you should be able to launch the server and its workers
+- Now you should be able to launch the server and its workers
 
 ```
 $ pipenv run python manage.py runserver
@@ -99,7 +96,6 @@ DB_HOST=db
 DB_USER=hawkpost
 DB_PASSWORD=hawkpost
 REDIS_URL=redis://redis:6379/0
-EMAIL_HOST=mail_debug
 ```
 
 **Don't forget to set the remaining variables** as well.
@@ -115,9 +111,9 @@ $ docker-compose up -d db redis
 # (using `--rm` to remove the temporary container afterwards)
 $ docker-compose run --rm web pipenv run python manage.py migrate
 
-# Run the web, celery and mail_debug containers
+# Run the web and celery containers
 # (`docker-compose up` would log db and redis as well)
-$ docker-compose up web celery mail_debug
+$ docker-compose up web celery
 ```
 
 These commands
@@ -126,9 +122,8 @@ These commands
    we're not bothered by their logs while working on the application.
 1. **Perform the migrations** using a temporary `web` container; it is removed
    afterwards.
-1. **Run the `web`, `celery` and `mail_debug` containers** attached to the
-   console. `mail_debug` is optional since it is only used when debugging the
-   e-mails being sent.
+1. **Run the `web` and `celery`** attached to the
+   console.
 
 The `web` container will reload on code changes.
 
@@ -156,13 +151,13 @@ network feature may require additional steps.
 
 # Running the test suite
 
-To execute our current test suite, you just need to execute the following command after settinng up your local development environment:
+To execute our current test suite, you just need to execute the following command after setting up your local development environment:
 
-> $ pipenv run python manage.py test
+> \$ pipenv run python manage.py test
 
 In case you are using our docker setup the command should be:
 
-> $ docker-compose run --rm web pipenv run python manage.py test
+> \$ docker-compose run --rm web pipenv run python manage.py test
 
 # Credits
 

--- a/boxes/models.py
+++ b/boxes/models.py
@@ -26,7 +26,9 @@ class Box(models.Model):
                             verbose_name=_('Unique ID'))
 
     owner = models.ForeignKey(settings.AUTH_USER_MODEL,
-                              related_name='own_boxes', verbose_name=_('Owner'))
+                              on_delete=models.CASCADE,
+                              related_name='own_boxes',
+                              verbose_name=_('Owner'))
 
     recipients = models.ManyToManyField(settings.AUTH_USER_MODEL,
                                         related_name='boxes',
@@ -84,8 +86,9 @@ class Membership(models.Model):
                                       verbose_name=_('Created at'))
     updated_at = models.DateTimeField(auto_now=True,
                                       verbose_name=_('Updated at'))
-    box = models.ForeignKey("Box")
-    user = models.ForeignKey(settings.AUTH_USER_MODEL)
+    box = models.ForeignKey("Box", on_delete=models.CASCADE)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL,
+                             on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = _('Membership')
@@ -107,7 +110,8 @@ class Message(models.Model):
         (FAILED, _('Failed'))
     )
 
-    box = models.ForeignKey("Box", related_name='messages')
+    box = models.ForeignKey(
+        "Box", on_delete=models.CASCADE, related_name='messages')
     status = models.IntegerField(choices=STATUSES, default=ONQUEUE,
                                  verbose_name=_('Status'))
     created_at = models.DateTimeField(auto_now_add=True,

--- a/boxes/tests.py
+++ b/boxes/tests.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from django.utils import timezone
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core import mail
 from humans.models import User
 from datetime import timedelta

--- a/boxes/views.py
+++ b/boxes/views.py
@@ -1,6 +1,6 @@
 from django.views.generic import ListView, CreateView, DeleteView, UpdateView
 from django.http import HttpResponseRedirect
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib import messages
 from django.utils import timezone
@@ -47,7 +47,7 @@ class BoxCreateView(JSONResponseMixin, LoginRequiredMixin, CreateView):
     def dispatch(self, request, *args, **kwargs):
         # Check if user can create boxes:
         user = request.user
-        if user.is_authenticated() and not user.has_setup_complete():
+        if user.is_authenticated and not user.has_setup_complete():
             url = reverse_lazy("humans_update") + "?setup=1"
             return self.render_to_response({"location": url})
 
@@ -175,7 +175,7 @@ class BoxSubmitView(UpdateView):
                 self.object.save()
 
             add_user_email = cleaned_data.get("add_reply_to", False)
-            if request.user.is_authenticated() and add_user_email:
+            if request.user.is_authenticated and add_user_email:
                 user_email = request.user.email
             else:
                 user_email = None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 
 services:
   web:
@@ -15,17 +15,6 @@ services:
     command: pipenv run celery -A hawkpost worker --beat -l info
     volumes:
       - "./gpg_home:/home/user/.gnupg"
-
-  mail_debug:
-    extends:
-      file: common.yml
-      service: app
-    command: pipenv run python manage.py mail_debug --settings hawkpost.settings.development --use-settings
-    ports:
-      - "1025:1025"
-    environment:
-      EMAIL_HOST: 0.0.0.0
-      EMAIL_PORT: 1025
 
   db:
     image: postgres:9

--- a/hawkpost/middleware.py
+++ b/hawkpost/middleware.py
@@ -1,14 +1,16 @@
 from django.utils import timezone, translation
+from django.utils.deprecation import MiddlewareMixin
 
 
-class TimezoneMiddleware():
+class TimezoneMiddleware(MiddlewareMixin):
     def process_request(self, request):
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             timezone.activate(request.user.timezone)
         else:
             timezone.deactivate()
 
-class LanguageMiddleware():
+
+class LanguageMiddleware(MiddlewareMixin):
     def process_request(self, request):
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             translation.activate(request.user.language)

--- a/hawkpost/settings/common.py
+++ b/hawkpost/settings/common.py
@@ -9,7 +9,7 @@ https://docs.djangoproject.com/en/1.9/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.9/ref/settings/
 """
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 import os
 
@@ -48,7 +48,7 @@ INSTALLED_APPS = [
     'pages',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -56,11 +56,11 @@ MIDDLEWARE_CLASSES = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'hawkpost.middleware.TimezoneMiddleware',
     'hawkpost.middleware.LanguageMiddleware',
+    'axes.middleware.AxesMiddleware'
 ]
 
 ROOT_URLCONF = 'hawkpost.urls'
@@ -106,6 +106,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Authentication settings
 
 AUTHENTICATION_BACKENDS = (
+    'axes.backends.AxesBackend',
     # Needed to login by username in Django admin, regardless of `allauth`
     'django.contrib.auth.backends.ModelBackend',
     # `allauth` specific authentication methods, such as login by e-mail
@@ -123,8 +124,8 @@ SITE_ID = 1
 
 LANGUAGE_CODE = 'en-us'
 LANGUAGES = [
-            ('en-us', _('English')),
-            ('pt-pt', _('Portuguese'))
+    ('en-us', _('English')),
+    ('pt-pt', _('Portuguese'))
 ]
 
 TIME_ZONE = 'UTC'
@@ -179,10 +180,9 @@ SOCIALACCOUNT_PROVIDERS = {
 }
 
 # Authentication Limits Config (AXES)
-AXES_LOGIN_FAILURE_LIMIT = 5
+AXES_FAILURE_LIMIT = 5
 AXES_COOLOFF_TIME = 1  # hour
 AXES_USERNAME_FORM_FIELD = 'login'
-AXES_DISABLE_SUCCESS_ACCESS_LOG = True
 
 # Email Settings
 DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL")

--- a/hawkpost/settings/development.py
+++ b/hawkpost/settings/development.py
@@ -32,11 +32,9 @@ INSTALLED_APPS += (
     'django_extensions',
 )
 
-MIDDLEWARE_CLASSES.insert(0, 'debug_toolbar.middleware.DebugToolbarMiddleware')
+MIDDLEWARE.insert(0, 'debug_toolbar.middleware.DebugToolbarMiddleware')
 
-EMAIL_HOST = os.environ.get("EMAIL_HOST", "127.0.0.1")
-EMAIL_PORT = os.environ.get("EMAIL_PORT", 1025)
-
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 DEBUG_TOOLBAR_PANELS = [
     'debug_toolbar.panels.versions.VersionsPanel',

--- a/hawkpost/urls.py
+++ b/hawkpost/urls.py
@@ -17,13 +17,23 @@ from django.conf import settings
 from django.conf.urls import url, include
 from django.contrib import admin
 from django.conf.urls.i18n import i18n_patterns
-from axes.decorators import watch_login
-from allauth.account.views import login
+from django.utils.decorators import method_decorator
+
+from allauth.account.views import LoginView
+from axes.decorators import axes_dispatch
+from axes.decorators import axes_form_invalid
+
+from humans.forms import LoginForm
+
+LoginView.dispatch = method_decorator(axes_dispatch)(LoginView.dispatch)
+LoginView.form_invalid = method_decorator(
+    axes_form_invalid)(LoginView.form_invalid)
 
 urlpatterns = [
-    url(r'^admin/login/$', watch_login(admin.site.login)),
+    url(r'^admin/login/$', admin.site.login),
     url(r'^admin/', admin.site.urls),
-    url(r'^users/login/$', watch_login(login)),
+    url(r'^users/login/$', LoginView.as_view(form_class=LoginForm),
+        name='account_login'),
     url(r'^users/', include('allauth.urls')),
     url(r'^users/', include('humans.urls')),
     url(r'^box/', include('boxes.urls')),

--- a/humans/admin.py
+++ b/humans/admin.py
@@ -35,7 +35,7 @@ class NotificationAdmin(admin.ModelAdmin):
     fields = ["subject", "body", "send_to"]
     search_fields = ['subject', 'body']
 
-    actions = ["send_notification", "delete_selected"]
+    actions = ["send_notification"]
 
     def delete_model(self, request, obj):
         if obj.sent_at:
@@ -58,8 +58,8 @@ class NotificationAdmin(admin.ModelAdmin):
         queryset.update(sent_at=timezone.now())
         messages.success(request, _('All notifications enqueued for sending'))
 
-    send_notification.short_description = _('Send selected notifications')
     delete_selected.short_description = _('Delete selected notifications')
+    send_notification.short_description = _('Send selected notifications')
 
 
 @admin.register(KeyChangeRecord)

--- a/humans/forms.py
+++ b/humans/forms.py
@@ -30,8 +30,8 @@ class UpdateUserInfoForm(ModelForm):
         }
 
     current_password = forms.CharField(label=_('Current password'),
-                                   required=False,
-                                   widget=forms.PasswordInput)
+                                       required=False,
+                                       widget=forms.PasswordInput)
     new_password1 = forms.CharField(label=_('New password'),
                                     required=False,
                                     widget=forms.PasswordInput)
@@ -135,6 +135,12 @@ class LoginForm(BaseLoginForm):
         self.fields['login'].widget.attrs["placeholder"] = ""
         self.fields['password'].widget.attrs["placeholder"] = ""
         self.fields['password'].widget.attrs["autocomplete"] = "off"
+
+    def user_credentials(self):
+        credentials = super().user_credentials()
+        credentials['login'] = credentials.get(
+            'email') or credentials.get('username')
+        return credentials
 
 
 class SignupForm(BaseSignupForm):

--- a/humans/models.py
+++ b/humans/models.py
@@ -14,12 +14,17 @@ class User(AbstractUser):
         ('pt-pt', _('Portuguese')),
     )
 
-    organization = models.CharField(null=True, blank=True, max_length=80, verbose_name=_('Organization'))
-    public_key = models.TextField(blank=True, null=True, verbose_name=_('Public key'))
-    fingerprint = models.CharField(null=True, blank=True, max_length=50, verbose_name=_('Fingerprint'))
-    keyserver_url = models.URLField(null=True, blank=True, verbose_name=_('Key server URL'))
+    organization = models.CharField(
+        null=True, blank=True, max_length=80, verbose_name=_('Organization'))
+    public_key = models.TextField(
+        blank=True, null=True, verbose_name=_('Public key'))
+    fingerprint = models.CharField(
+        null=True, blank=True, max_length=50, verbose_name=_('Fingerprint'))
+    keyserver_url = models.URLField(
+        null=True, blank=True, verbose_name=_('Key server URL'))
     timezone = TimeZoneField(default='UTC', verbose_name=_('Timezone'))
-    language = models.CharField(default="en-us", max_length=16, choices=LANGUAGE_CHOICES , verbose_name=_('Language'))
+    language = models.CharField(
+        default="en-us", max_length=16, choices=LANGUAGE_CHOICES, verbose_name=_('Language'))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -61,14 +66,18 @@ class Notification(models.Model):
         by an Administrator. Just once.
     """
 
-    subject = models.CharField(null=False, blank=False, max_length=150, verbose_name=_('Subject'))
+    subject = models.CharField(
+        null=False, blank=False, max_length=150, verbose_name=_('Subject'))
     body = models.TextField(null=False, blank=False, verbose_name=_('Body'))
 
-    created_at = models.DateTimeField(auto_now_add=True, verbose_name=_('Created at'))
-    updated_at = models.DateTimeField(auto_now=True, verbose_name=_('Updated at'))
+    created_at = models.DateTimeField(
+        auto_now_add=True, verbose_name=_('Created at'))
+    updated_at = models.DateTimeField(
+        auto_now=True, verbose_name=_('Updated at'))
 
     sent_at = models.DateTimeField(null=True, verbose_name=_('Sent at'))
-    send_to = models.ForeignKey(Group, null=True, blank=True, verbose_name=_('Send to'))
+    send_to = models.ForeignKey(
+        Group, null=True, blank=True, on_delete=models.CASCADE, verbose_name=_('Send to'))
 
     class Meta:
         verbose_name = _('Notification')
@@ -86,6 +95,7 @@ class KeyChangeRecord(models.Model):
         This allows the user to be aware of any suspicious activity
     """
     user = models.ForeignKey(User,
+                             on_delete=models.CASCADE,
                              related_name='keychanges',
                              verbose_name=_('User'))
     prev_fingerprint = models.CharField(null=True,

--- a/humans/views.py
+++ b/humans/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin as LoginRequired
 from django.contrib.auth import logout, authenticate
 from django.contrib.auth import update_session_auth_hash
 from django.views.generic import FormView, DeleteView
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 from django.contrib import messages
 from django.conf import settings
@@ -19,7 +19,7 @@ class LoginRequiredMixin(LoginRequired):
 class AuthMixin():
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        if not self.request.user.is_authenticated():
+        if not self.request.user.is_authenticated:
             context["login_form"] = LoginForm()
             context["signup_form"] = SignupForm()
         return context
@@ -71,7 +71,7 @@ class DeleteUserView(LoginRequiredMixin, DeleteView):
 
     def delete(self, request, *args, **kwargs):
         current_pw = request.POST.get("current_password", "")
-        if authenticate(username=request.user.username, password=current_pw):
+        if authenticate(username=request.user.username, password=current_pw, request=request):
             response = super().delete(request, *args, **kwargs)
             logout(request)
             messages.success(request,


### PR DESCRIPTION
The project hasn't been updated for a long time and some of the dependencies weren't supported anymore. So this PR:

* Updates `django` to latest LTS
* Updates `django-axes` for the latest major version
* Updates `redis` lib
* Updates `django-allauth`

Also since we don't need a separate container/process to print the emails on the console during development, because already provides a backend for that, I removed the extra container and updated the settings.